### PR TITLE
use config to provide smaller initial size and growth increments for …

### DIFF
--- a/nordic-nrf51822-16k-armcc/target.json
+++ b/nordic-nrf51822-16k-armcc/target.json
@@ -18,7 +18,12 @@
     "nordic",
     "armcc"
   ],
-  "config": {},
+  "config": {
+    "minar": {
+      "initial_event_pool_size"    : 4,
+      "additional_event_pools_size": 4
+    }
+  },
   "similarTo": [
     "nrf51822",
     "nrf",

--- a/nordic-nrf51822-16k-gcc/target.json
+++ b/nordic-nrf51822-16k-gcc/target.json
@@ -18,7 +18,12 @@
     "nordic",
     "gcc"
   ],
-  "config": {},
+  "config": {
+    "minar": {
+      "initial_event_pool_size"    : 4,
+      "additional_event_pools_size": 4
+    }
+  },
   "similarTo": [
     "nrf51822",
     "nrf",

--- a/nordic-nrf51822-32k-armcc/target.json
+++ b/nordic-nrf51822-32k-armcc/target.json
@@ -18,7 +18,12 @@
     "nordic",
     "armcc"
   ],
-  "config": {},
+  "config": {
+    "minar": {
+      "initial_event_pool_size"    : 4,
+      "additional_event_pools_size": 4
+    }
+  },
   "similarTo": [
     "nrf51822",
     "nrf",

--- a/nordic-nrf51822-32k-gcc/target.json
+++ b/nordic-nrf51822-32k-gcc/target.json
@@ -18,7 +18,12 @@
     "nordic",
     "gcc"
   ],
-  "config": {},
+  "config": {
+    "minar": {
+      "initial_event_pool_size"    : 4,
+      "additional_event_pools_size": 4
+    }
+  },
   "similarTo": [
     "nrf51822",
     "nrf",


### PR DESCRIPTION
…the pool of minar::CallbackNodes.

This is required due to the memory constraints imposed by nRF5x.

@autopulated @0xc0170 