### PR TITLE
add "mbed-os : true" to the config for targets.

### DIFF
--- a/nordic-nrf51822-16k-armcc/target.json
+++ b/nordic-nrf51822-16k-armcc/target.json
@@ -19,6 +19,7 @@
     "armcc"
   ],
   "config": {
+    "mbed-os" : true,
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4

--- a/nordic-nrf51822-16k-gcc/target.json
+++ b/nordic-nrf51822-16k-gcc/target.json
@@ -19,6 +19,7 @@
     "gcc"
   ],
   "config": {
+    "mbed-os" : true,
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4

--- a/nordic-nrf51822-32k-armcc/target.json
+++ b/nordic-nrf51822-32k-armcc/target.json
@@ -19,6 +19,7 @@
     "armcc"
   ],
   "config": {
+    "mbed-os" : true,
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4

--- a/nordic-nrf51822-32k-gcc/target.json
+++ b/nordic-nrf51822-32k-gcc/target.json
@@ -19,6 +19,7 @@
     "gcc"
   ],
   "config": {
+    "mbed-os" : true,
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4


### PR DESCRIPTION
bbcmicro targets inherit from mbed-* directly, and won't be affected.

This config will be used to make a compile-time switch in the Nordic port of BLE API to put events into the scheduler (as opposed to executing them directly in interrupt context). It will also be used to select target-dependencies for the ble module (so that it inherits mbed-drivers instead of mbed-classic).

CR @autopulated @0xc0170 