### PR TITLE
Remove SRecord dependency for nordic-nrf51822-32k-gcc

### DIFF
--- a/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
@@ -23,6 +23,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-
 
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${CMAKE_CURRENT_LIST_DIR}/../softdevice/s130_nrf51_1.0.0_softdevice.hex")
+set(NRF51822_MERGE_HEX_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -34,7 +35,7 @@ function(yotta_apply_target_rules target_type target_name)
             # objcopy to hex
             COMMAND arm-none-eabi-objcopy -O ihex ${target_name} ${target_name}.hex
             # and append the softdevice hex file
-            COMMAND srec_cat ${NRF51822_SOFTDEVICE_HEX_FILE} -intel ${target_name}.hex -intel -o ${target_name}-combined.hex -intel --line-length=44
+            COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
             VERBATIM
         )

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python
 
-"""This script will merge two hex files and write the output to a hex file
-   USAGE: merge_hex.py input_file1 input_file2 output_file
+"""This script will merge two hex files and write the output to a hex file.
+   USAGE: merge_hex.py input_file1 input_file2 output_file.
 """
 
 import sys
-from intelhex import IntelHex
 
 def main(arguments):
+    try:
+        from intelhex import IntelHex
+    except:
+        fail_color = '\033[91m'
+        print(fail_color + 'error: You do not have \'intelhex\' installed. Please run \'pip install intelhex\' then retry.')
+        return 1
+
     if not len(arguments) == 3:
+        print(fail_color + 'error: Improper use of merge_hex.py.')
+	print(fail_color + 'USAGE: merge_hex.py input_file1 input_file2 output_file.')
         return 1
 
     orig = IntelHex(arguments[0])

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -10,9 +10,10 @@ fail_color = ''
 
 # If colorama is present, set the fail color to red
 try:
-    from colorama import init, Fore
+    from colorama import init, deinit, Fore
     fail_color = Fore.RED
-
+except:
+    pass
 
 def fail(message):
     print(fail_color + message)

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+"""This script will merge two hex files and write the output to a hex file
+   USAGE: merge_hex.py input_file1 input_file2 output_file
+"""
+
+import sys
+from intelhex import IntelHex
+
+def main(arguments):
+    if not len(arguments) == 3:
+        return 1
+
+    orig = IntelHex(arguments[0])
+    new = IntelHex(arguments[1])
+    orig.merge(new, overlap='replace')
+    orig.write_hex_file(arguments[2])
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -6,19 +6,40 @@
 
 import sys
 
+fail_color = ''
+
+# If colorama is present, set the fail color to red
+try:
+    from colorama import init, Fore
+    fail_color = Fore.RED
+
+
+def fail(message):
+    print(fail_color + message)
+
+    # If we've included ANSI color in output, reset the output style
+    if fail_color:
+        print(Fore.RESET)
+        deinit()
+
+    return 1
+
 def main(arguments):
+    # If using ANSI coloring is available, initialize colorama
+    if fail_color:
+        init()
+
+    # Import intelhex if avaialable, otherwise fail
     try:
         from intelhex import IntelHex
     except:
-        fail_color = '\033[91m'
-        print(fail_color + 'error: You do not have \'intelhex\' installed. Please run \'pip install intelhex\' then retry.')
-        return 1
+        return fail('error: You do not have \'intelhex\' installed. Please run \'pip install intelhex\' then retry.')
 
+    # Ensure the right number of arguments are supplied
     if not len(arguments) == 3:
-        print(fail_color + 'error: Improper use of merge_hex.py.')
-	print(fail_color + 'USAGE: merge_hex.py input_file1 input_file2 output_file.')
-        return 1
+        return fail('error: Improper use of merge_hex.py.\nUSAGE: merge_hex.py input_file1 input_file2 output_file.')
 
+    # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
     new = IntelHex(arguments[1])
     orig.merge(new, overlap='replace')


### PR DESCRIPTION
This PR demonstrates how the SRecord dependency can be removed from the nordic targets.

This instead uses a pip package called 'intelhex', so it can be included in yotta's requirements instead having to be installed separately. intelhex has been used in the mbed 2.0 build/test system, so it is fairly well tested.

@rgrover @bogdanm, do you have any opinions/feedback?