### PR TITLE
expose the 16/32k chip variant information in config

### DIFF
--- a/nordic-nrf51822-16k-armcc/target.json
+++ b/nordic-nrf51822-16k-armcc/target.json
@@ -28,6 +28,11 @@
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4
+    },
+    "chip":{
+        "nrf51822": {
+            "16k": true
+        }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-16k-gcc/target.json
+++ b/nordic-nrf51822-16k-gcc/target.json
@@ -28,6 +28,11 @@
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4
+    },
+    "chip":{
+        "nrf51822": {
+            "16k": true
+        }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-32k-armcc/target.json
+++ b/nordic-nrf51822-32k-armcc/target.json
@@ -28,6 +28,11 @@
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4
+    },
+    "chip":{
+        "nrf51822": {
+            "32k": true
+        }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-32k-gcc/target.json
+++ b/nordic-nrf51822-32k-gcc/target.json
@@ -28,6 +28,11 @@
     "minar": {
       "initial_event_pool_size": 4,
       "additional_event_pools_size": 4
+    },
+    "chip":{
+        "nrf51822": {
+            "32k": true
+        }
     }
   },
   "similarTo": [


### PR DESCRIPTION
This information can be used to select the startup assembly from CMake, avoiding the need to preprocess assembly (working around the lack of supporting armcc for preprocessing assembly on windows).

@bogdanm @rgrover 