### PR TITLE
Updating merge_hex.py scripts to work with older nordic firmware

### DIFF
--- a/nordic-nrf51822-16k-armcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-16k-armcc/scripts/merge_hex.py
@@ -25,6 +25,11 @@ def fail(message):
 
     return 1
 
+def convert_start_addr(hex_file):
+    if hex_file.start_addr and 'CS' in hex_file.start_addr:
+        start_addr = {'EIP': (hex_file.start_addr['CS'] * 16) + hex_file.start_addr['IP']}
+        hex_file.start_addr = start_addr
+
 def main(arguments):
     # If using ANSI coloring is available, initialize colorama
     if fail_color:
@@ -42,7 +47,11 @@ def main(arguments):
 
     # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
+    convert_start_addr(orig)    
+
     new = IntelHex(arguments[1])
+    convert_start_addr(new)
+    
     orig.merge(new, overlap='replace')
     orig.write_hex_file(arguments[2])
 

--- a/nordic-nrf51822-16k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-16k-gcc/scripts/merge_hex.py
@@ -25,6 +25,11 @@ def fail(message):
 
     return 1
 
+def convert_start_addr(hex_file):
+    if hex_file.start_addr and 'CS' in hex_file.start_addr:
+        start_addr = {'EIP': (hex_file.start_addr['CS'] * 16) + hex_file.start_addr['IP']}
+        hex_file.start_addr = start_addr
+
 def main(arguments):
     # If using ANSI coloring is available, initialize colorama
     if fail_color:
@@ -42,7 +47,11 @@ def main(arguments):
 
     # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
+    convert_start_addr(orig)    
+
     new = IntelHex(arguments[1])
+    convert_start_addr(new)
+    
     orig.merge(new, overlap='replace')
     orig.write_hex_file(arguments[2])
 

--- a/nordic-nrf51822-32k-armcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-armcc/scripts/merge_hex.py
@@ -25,6 +25,11 @@ def fail(message):
 
     return 1
 
+def convert_start_addr(hex_file):
+    if hex_file.start_addr and 'CS' in hex_file.start_addr:
+        start_addr = {'EIP': (hex_file.start_addr['CS'] * 16) + hex_file.start_addr['IP']}
+        hex_file.start_addr = start_addr
+
 def main(arguments):
     # If using ANSI coloring is available, initialize colorama
     if fail_color:
@@ -42,7 +47,11 @@ def main(arguments):
 
     # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
+    convert_start_addr(orig)    
+
     new = IntelHex(arguments[1])
+    convert_start_addr(new)
+    
     orig.merge(new, overlap='replace')
     orig.write_hex_file(arguments[2])
 

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -25,6 +25,11 @@ def fail(message):
 
     return 1
 
+def convert_start_addr(hex_file):
+    if hex_file.start_addr and 'CS' in hex_file.start_addr:
+        start_addr = {'EIP': (hex_file.start_addr['CS'] * 16) + hex_file.start_addr['IP']}
+        hex_file.start_addr = start_addr
+
 def main(arguments):
     # If using ANSI coloring is available, initialize colorama
     if fail_color:
@@ -42,7 +47,11 @@ def main(arguments):
 
     # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
+    convert_start_addr(orig)    
+
     new = IntelHex(arguments[1])
+    convert_start_addr(new)
+    
     orig.merge(new, overlap='replace')
     orig.write_hex_file(arguments[2])
 


### PR DESCRIPTION
@autopulated Turns out those lines were important :)

I had some newer fimware on the DK board that was able to deal with those lines, but the public firmware on developer.mbed.org can't. This fixes that issue.