### PR TITLE
add appropriate license headers; also mention permission for SoftDevice

### DIFF
--- a/BSD-3clause-Nordic.txt
+++ b/BSD-3clause-Nordic.txt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of other
+ *   contributors to this software may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,7 @@
+Many of the files in this module have been inherited from the Nordic SDK for
+nRF51822; they come with a BSD license offered by Nordic for use in mbed.
+Nordic Semiconductor has granted permission to bundle the SoftDevice with mbed.
+Some other files come from the mbed SDK, and are licensed under Apache-2.0.
 Unless specifically indicated otherwise in a file, files are licensed
-under the Apache 2.0 license, as can be found in: apache-2.0.txt
+under the Apache 2.0 license, as can be found in: apache-2.0.txt.
+The BSD Nordic license can be found in BSD-3clause-Nordic.txt

--- a/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
@@ -1,4 +1,16 @@
-# Copyright (C) 2014-2015 ARM Limited. All rights reserved.
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if(TARGET_NORDIC_NRF51822_16K_ARMCC_TOOLCHAIN_INCLUDED)
     return()
@@ -36,7 +48,7 @@ function(yotta_apply_target_rules target_type target_name)
             # fromelf to hex
             COMMAND fromelf --i32combined --output=${target_name}.hex ${target_name}
             # and append the softdevice hex file
-            COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex            
+            COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMAND srec_info ${target_name}-combined.hex -intel
             COMMENT "hexifying and adding softdevice to ${target_name}"
             VERBATIM

--- a/nordic-nrf51822-16k-armcc/ld/nRF51822.sct
+++ b/nordic-nrf51822-16k-armcc/ld/nRF51822.sct
@@ -1,3 +1,17 @@
+; Copyright (c) 2015 ARM Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 ;WITHOUT SOFTDEVICE:
 ;LR_IROM1 0x00000000 0x00040000  {
 ;  ER_IROM1 0x00000000 0x00040000  {

--- a/nordic-nrf51822-16k-armcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-16k-armcc/scripts/merge_hex.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """This script will merge two hex files and write the output to a hex file.
    USAGE: merge_hex.py input_file1 input_file2 output_file.
 """
@@ -47,11 +61,11 @@ def main(arguments):
 
     # Get the two hex files, merge them, and save the result
     orig = IntelHex(arguments[0])
-    convert_start_addr(orig)    
+    convert_start_addr(orig)
 
     new = IntelHex(arguments[1])
     convert_start_addr(new)
-    
+
     orig.merge(new, overlap='replace')
     orig.write_hex_file(arguments[2])
 

--- a/nordic-nrf51822-16k-armcc/softdevice/LICENSE
+++ b/nordic-nrf51822-16k-armcc/softdevice/LICENSE
@@ -1,0 +1,1 @@
+Nordic Semiconductor has granted permission to bundle the SoftDevice with mbed.

--- a/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
@@ -1,4 +1,16 @@
-# Copyright (C) 2014-2015 ARM Limited. All rights reserved.
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if(TARGET_NORDIC_NRF51822_16K_GCC_TOOLCHAIN_INCLUDED)
     return()

--- a/nordic-nrf51822-16k-gcc/ld/NRF51822.ld
+++ b/nordic-nrf51822-16k-gcc/ld/NRF51822.ld
@@ -1,4 +1,19 @@
-/*TODO: Add stuff for uvisor*/
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* Linker script to configure memory regions. */
 
 MEMORY

--- a/nordic-nrf51822-16k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-16k-gcc/scripts/merge_hex.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """This script will merge two hex files and write the output to a hex file.
    USAGE: merge_hex.py input_file1 input_file2 output_file.
 """

--- a/nordic-nrf51822-16k-gcc/softdevice/LICENSE
+++ b/nordic-nrf51822-16k-gcc/softdevice/LICENSE
@@ -1,0 +1,1 @@
+Nordic Semiconductor has granted permission to bundle the SoftDevice with mbed.

--- a/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
@@ -1,4 +1,16 @@
-# Copyright (C) 2014-2015 ARM Limited. All rights reserved.
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if(TARGET_NORDIC_NRF51822_32K_ARMCC_TOOLCHAIN_INCLUDED)
     return()

--- a/nordic-nrf51822-32k-armcc/ld/nRF51822.sct
+++ b/nordic-nrf51822-32k-armcc/ld/nRF51822.sct
@@ -1,3 +1,17 @@
+; Copyright (c) 2015 ARM Limited
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
 ;WITHOUT SOFTDEVICE:
 ;LR_IROM1 0x00000000 0x00040000  {
 ;  ER_IROM1 0x00000000 0x00040000  {

--- a/nordic-nrf51822-32k-armcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-armcc/scripts/merge_hex.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """This script will merge two hex files and write the output to a hex file.
    USAGE: merge_hex.py input_file1 input_file2 output_file.
 """

--- a/nordic-nrf51822-32k-armcc/softdevice/LICENSE
+++ b/nordic-nrf51822-32k-armcc/softdevice/LICENSE
@@ -1,0 +1,1 @@
+Nordic Semiconductor has granted permission to bundle the SoftDevice with mbed.

--- a/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
@@ -1,4 +1,16 @@
-# Copyright (C) 2014-2015 ARM Limited. All rights reserved. 
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if(TARGET_NORDIC_NRF51822_32K_GCC_TOOLCHAIN_INCLUDED)
     return()

--- a/nordic-nrf51822-32k-gcc/ld/NRF51822.ld
+++ b/nordic-nrf51822-32k-gcc/ld/NRF51822.ld
@@ -1,4 +1,19 @@
-/*TODO: add mbedOS stuff for uvisor support*/
+/*
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* Linker script to configure memory regions. */
 
 MEMORY

--- a/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
+++ b/nordic-nrf51822-32k-gcc/scripts/merge_hex.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright (c) 2015 ARM Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """This script will merge two hex files and write the output to a hex file.
    USAGE: merge_hex.py input_file1 input_file2 output_file.
 """

--- a/nordic-nrf51822-32k-gcc/softdevice/LICENSE
+++ b/nordic-nrf51822-32k-gcc/softdevice/LICENSE
@@ -1,0 +1,1 @@
+Nordic Semiconductor has granted permission to bundle the SoftDevice with mbed.


### PR DESCRIPTION
@bogdanm @hugovincent @aewp2 @0xc0170 
Please note that I've added mention for our right to distribute the softdevice in the top level LICENSE. I've also added separate LICENSE files alongside each softdevice.hex.
I'm not sure why we need to include the softdevice in the target (given that it is already included in the nordic hal), but this is not the time for this.
