### PR TITLE
Add yotta config to make LFCLK the default

### DIFF
--- a/nordic-nrf51822-16k-armcc/target.json
+++ b/nordic-nrf51822-16k-armcc/target.json
@@ -39,6 +39,13 @@
       "nrf51822": {
         "16k": true
       }
+    },
+    "hardware": {
+      "clocks": {
+        "nrf": {
+          "lfclk_src": 1
+        }
+      }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-16k-gcc/target.json
+++ b/nordic-nrf51822-16k-gcc/target.json
@@ -39,6 +39,13 @@
       "nrf51822": {
         "16k": true
       }
+    },
+    "hardware": {
+      "clocks": {
+        "nrf": {
+          "lfclk_src": 1
+        }
+      }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-32k-armcc/target.json
+++ b/nordic-nrf51822-32k-armcc/target.json
@@ -39,6 +39,13 @@
       "nrf51822": {
         "32k": true
       }
+    },
+    "hardware": {
+      "clocks": {
+        "nrf": {
+          "lfclk_src": 1
+        }
+      }
     }
   },
   "similarTo": [

--- a/nordic-nrf51822-32k-gcc/target.json
+++ b/nordic-nrf51822-32k-gcc/target.json
@@ -39,6 +39,13 @@
       "nrf51822": {
         "32k": true
       }
+    },
+    "hardware": {
+      "clocks": {
+        "nrf": {
+          "lfclk_src": 1
+        }
+      }
     }
   },
   "similarTo": [


### PR DESCRIPTION
When creating the bbc-microbit targets the module cmsis-core-nrf51822 was modified to allow easy disabling checks of the low-frequency clock (LFCLK) otherwise all mbed os programs running in microbit will get stuck in an infinite loop. Hence, the yotta config macro YOTTA_CFG_HARDWARE_CLOCKS_NRF_LFCLK_SRC was introduced to easily enable/disable the checks. The config is included in this target to enable LFCLK by default.