### PR TITLE
Add script that to print memory usage info

### DIFF
--- a/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
@@ -53,6 +53,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} --info=totals
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
 set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -67,6 +68,9 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            # printing memory usage information
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMENT "printing memory usage information"
             VERBATIM
         )
     endif()

--- a/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-armcc/CMake/toolchain.cmake
@@ -51,9 +51,10 @@ set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_O
 set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} --info=totals --list=.link_totals.txt --scatter ${NRF51822_LINKER_FLAGS_FILE_PATH}")
 
 # used by the apply_target_rules function below:
-set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
-set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
-set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_SOFTDEVICE_HEX_FILE    "${NRF51822_SOFTDEVICE_FILE_PATH}")
+set(NRF51822_MERGE_HEX_SCRIPT       "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT     "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_HEAP_WARNING_THRESHOLD 1024)
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -68,8 +69,12 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            VERBATIM
+        )
+        add_custom_command(TARGET ${target_name}
+            POST_BUILD
             # printing memory usage information
-            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name} ${NRF51822_HEAP_WARNING_THRESHOLD}
             COMMENT "printing memory usage information"
             VERBATIM
         )

--- a/nordic-nrf51822-16k-armcc/scripts/memory_info.py
+++ b/nordic-nrf51822-16k-armcc/scripts/memory_info.py
@@ -80,9 +80,7 @@ def main(arguments):
                 if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
                     warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
                 break
-        if len(compiled_patterns) == 0:
-            break
-    print('\n'.join(warnings_list))
+    print(os.linesep.join(warnings_list))
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-16k-armcc/scripts/memory_info.py
+++ b/nordic-nrf51822-16k-armcc/scripts/memory_info.py
@@ -1,0 +1,88 @@
+#! /usr/bin/env python
+
+"""This script reads the map file generated after the build process and prints
+   memory layout information of an nRF51 application.
+   USAGE: mem_report.py exec_filepath
+"""
+
+import sys
+import os.path
+import re
+import subprocess
+from distutils import spawn
+
+WARNING_THRESHOLD = 1024
+ARM_SIZE_UTILITY  = 'arm-none-eabi-size'
+
+fail_color    = ''
+warning_color = ''
+
+# If colorama is present, set the fail color to red
+try:
+    from colorama import init, deinit, Fore
+    fail_color    = Fore.RED
+    warning_color = Fore.BLUE
+except:
+    pass
+
+generic_pattern   = '^(?P<useful_info>(?P<section>{0})\\s+(?P<size>\\d+))\\s+\\d+$'
+compiled_patterns = [re.compile('^(?P<useful_info>(?P<section>section)\\s+size)\\s+addr$'),
+                     re.compile(generic_pattern.format('RW_IRAM1')), re.compile(generic_pattern.format('RW_IRAM1')),
+                     re.compile(generic_pattern.format('ARM_LIB_HEAP')), re.compile(generic_pattern.format('ARM_LIB_STACK'))]
+
+def fail(message):
+    print(fail_color + 'ERROR: ' + message)
+
+    # If we've included ANSI color in output, reset the output style
+    if fail_color:
+        print(Fore.RESET)
+        deinit()
+
+    return 1
+
+def warning(message):
+    output = warning_color + 'WARNING: ' + message
+
+    # If we've included ANSI color in output, reset the output style
+    if warning_color:
+        output += Fore.RESET
+        deinit()
+
+    return output
+
+def main(arguments):
+    # If using ANSI coloring is available, initialize colorama
+    if fail_color and warning_color:
+        init()
+
+    # Ensure the right number of arguments are supplied
+    if len(arguments) != 1:
+        return fail('Improper use of mem_report.py.\nUSAGE: mem_report.py exec_filepath')
+    exec_filepath = arguments[0]
+
+    # Test if required utility exists
+    if not spawn.find_executable(ARM_SIZE_UTILITY):
+        print(warning('\'{0}\' could not be found. No memory usage information will be reported.'.format(ARM_SIZE_UTILITY)))
+        return 0
+
+    # Execute arm-none-eabi-size and get output
+    process = subprocess.Popen([ARM_SIZE_UTILITY, '-A', exec_filepath], stdout=subprocess.PIPE)
+    stdout  = process.communicate()[0].strip()
+
+    # Process output to remove memory addresses and print warnings when heap is low
+    warnings_list = []
+    print('Memory usage for \'{0}\''.format(exec_filepath))
+    for line in stdout.split(os.linesep):
+        for index, pattern in enumerate(compiled_patterns):
+            match = re.match(pattern, line)
+            if match:
+                print(match.group('useful_info'))
+                if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
+                    warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
+                break
+        if len(compiled_patterns) == 0:
+            break
+    print('\n'.join(warnings_list))
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
@@ -51,9 +51,10 @@ set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} -mcpu=cort
 set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb -T\"${NRF51822_LINKER_FLAGS_FILE_PATH}\"")
 
 # used by the apply_target_rules function below:
-set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
-set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
-set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_SOFTDEVICE_HEX_FILE    "${NRF51822_SOFTDEVICE_FILE_PATH}")
+set(NRF51822_MERGE_HEX_SCRIPT       "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT     "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_HEAP_WARNING_THRESHOLD 1024)
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -67,8 +68,12 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            VERBATIM
+        )
+        add_custom_command(TARGET ${target_name}
+            POST_BUILD
             # printing memory usage information
-            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name} ${NRF51822_HEAP_WARNING_THRESHOLD}
             COMMENT "printing memory usage information"
             VERBATIM
         )

--- a/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-16k-gcc/CMake/toolchain.cmake
@@ -53,6 +53,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
 set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -66,6 +67,9 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            # printing memory usage information
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMENT "printing memory usage information"
             VERBATIM
         )
     endif()

--- a/nordic-nrf51822-16k-gcc/scripts/memory_info.py
+++ b/nordic-nrf51822-16k-gcc/scripts/memory_info.py
@@ -80,9 +80,7 @@ def main(arguments):
                 if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
                     warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
                 break
-        if len(compiled_patterns) == 0:
-            break
-    print('\n'.join(warnings_list))
+    print(os.linesep.join(warnings_list))
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-16k-gcc/scripts/memory_info.py
+++ b/nordic-nrf51822-16k-gcc/scripts/memory_info.py
@@ -1,0 +1,88 @@
+#! /usr/bin/env python
+
+"""This script reads the map file generated after the build process and prints
+   memory layout information of an nRF51 application.
+   USAGE: mem_report.py exec_filepath
+"""
+
+import sys
+import os.path
+import re
+import subprocess
+from distutils import spawn
+
+WARNING_THRESHOLD = 1024
+ARM_SIZE_UTILITY  = 'arm-none-eabi-size'
+
+fail_color    = ''
+warning_color = ''
+
+# If colorama is present, set the fail color to red
+try:
+    from colorama import init, deinit, Fore
+    fail_color    = Fore.RED
+    warning_color = Fore.BLUE
+except:
+    pass
+
+generic_pattern   = '^(?P<useful_info>\\.(?P<section>{0})\\s+(?P<size>\\d+))\\s+\\d+$'
+compiled_patterns = [re.compile('^(?P<useful_info>(?P<section>section)\\s+size)\\s+addr$'),
+                     re.compile(generic_pattern.format('data')), re.compile(generic_pattern.format('bss')),
+                     re.compile(generic_pattern.format('heap')), re.compile(generic_pattern.format('stack'))]
+
+def fail(message):
+    print(fail_color + 'ERROR: ' + message)
+
+    # If we've included ANSI color in output, reset the output style
+    if fail_color:
+        print(Fore.RESET)
+        deinit()
+
+    return 1
+
+def warning(message):
+    output = warning_color + 'WARNING: ' + message
+
+    # If we've included ANSI color in output, reset the output style
+    if warning_color:
+        output += Fore.RESET
+        deinit()
+
+    return output
+
+def main(arguments):
+    # If using ANSI coloring is available, initialize colorama
+    if fail_color and warning_color:
+        init()
+
+    # Ensure the right number of arguments are supplied
+    if len(arguments) != 1:
+        return fail('Improper use of mem_report.py.\nUSAGE: mem_report.py exec_filepath')
+    exec_filepath = arguments[0]
+
+    # Test if required utility exists
+    if not spawn.find_executable(ARM_SIZE_UTILITY):
+        print(warning('\'{0}\' could not be found. No memory usage information will be reported.'.format(ARM_SIZE_UTILITY)))
+        return 0
+
+    # Execute arm-none-eabi-size and get output
+    process = subprocess.Popen([ARM_SIZE_UTILITY, '-A', exec_filepath], stdout=subprocess.PIPE)
+    stdout  = process.communicate()[0].strip()
+
+    # Process output to remove memory addresses and print warnings when heap is low
+    warnings_list = []
+    print('Memory usage for \'{0}\''.format(exec_filepath))
+    for line in stdout.split(os.linesep):
+        for index, pattern in enumerate(compiled_patterns):
+            match = re.match(pattern, line)
+            if match:
+                print(match.group('useful_info'))
+                if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
+                    warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
+                break
+        if len(compiled_patterns) == 0:
+            break
+    print('\n'.join(warnings_list))
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
@@ -53,6 +53,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} --info=totals
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
 set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -67,6 +68,9 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            # printing memory usage information
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMENT "printing memory usage information"
             VERBATIM
         )
     endif()

--- a/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-armcc/CMake/toolchain.cmake
@@ -51,9 +51,10 @@ set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_O
 set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} --info=totals --list=.link_totals.txt --scatter ${NRF51822_LINKER_FLAGS_FILE_PATH}")
 
 # used by the apply_target_rules function below:
-set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
-set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
-set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_SOFTDEVICE_HEX_FILE    "${NRF51822_SOFTDEVICE_FILE_PATH}")
+set(NRF51822_MERGE_HEX_SCRIPT       "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT     "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_HEAP_WARNING_THRESHOLD 1024)
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -68,8 +69,12 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            VERBATIM
+        )
+        add_custom_command(TARGET ${target_name}
+            POST_BUILD
             # printing memory usage information
-            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name} ${NRF51822_HEAP_WARNING_THRESHOLD}
             COMMENT "printing memory usage information"
             VERBATIM
         )

--- a/nordic-nrf51822-32k-armcc/scripts/memory_info.py
+++ b/nordic-nrf51822-32k-armcc/scripts/memory_info.py
@@ -80,9 +80,7 @@ def main(arguments):
                 if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
                     warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
                 break
-        if len(compiled_patterns) == 0:
-            break
-    print('\n'.join(warnings_list))
+    print(os.linesep.join(warnings_list))
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-32k-armcc/scripts/memory_info.py
+++ b/nordic-nrf51822-32k-armcc/scripts/memory_info.py
@@ -1,0 +1,88 @@
+#! /usr/bin/env python
+
+"""This script reads the map file generated after the build process and prints
+   memory layout information of an nRF51 application.
+   USAGE: mem_report.py exec_filepath
+"""
+
+import sys
+import os.path
+import re
+import subprocess
+from distutils import spawn
+
+WARNING_THRESHOLD = 1024
+ARM_SIZE_UTILITY  = 'arm-none-eabi-size'
+
+fail_color    = ''
+warning_color = ''
+
+# If colorama is present, set the fail color to red
+try:
+    from colorama import init, deinit, Fore
+    fail_color    = Fore.RED
+    warning_color = Fore.BLUE
+except:
+    pass
+
+generic_pattern   = '^(?P<useful_info>(?P<section>{0})\\s+(?P<size>\\d+))\\s+\\d+$'
+compiled_patterns = [re.compile('^(?P<useful_info>(?P<section>section)\\s+size)\\s+addr$'),
+                     re.compile(generic_pattern.format('RW_IRAM1')), re.compile(generic_pattern.format('RW_IRAM1')),
+                     re.compile(generic_pattern.format('ARM_LIB_HEAP')), re.compile(generic_pattern.format('ARM_LIB_STACK'))]
+
+def fail(message):
+    print(fail_color + 'ERROR: ' + message)
+
+    # If we've included ANSI color in output, reset the output style
+    if fail_color:
+        print(Fore.RESET)
+        deinit()
+
+    return 1
+
+def warning(message):
+    output = warning_color + 'WARNING: ' + message
+
+    # If we've included ANSI color in output, reset the output style
+    if warning_color:
+        output += Fore.RESET
+        deinit()
+
+    return output
+
+def main(arguments):
+    # If using ANSI coloring is available, initialize colorama
+    if fail_color and warning_color:
+        init()
+
+    # Ensure the right number of arguments are supplied
+    if len(arguments) != 1:
+        return fail('Improper use of mem_report.py.\nUSAGE: mem_report.py exec_filepath')
+    exec_filepath = arguments[0]
+
+    # Test if required utility exists
+    if not spawn.find_executable(ARM_SIZE_UTILITY):
+        print(warning('\'{0}\' could not be found. No memory usage information will be reported.'.format(ARM_SIZE_UTILITY)))
+        return 0
+
+    # Execute arm-none-eabi-size and get output
+    process = subprocess.Popen([ARM_SIZE_UTILITY, '-A', exec_filepath], stdout=subprocess.PIPE)
+    stdout  = process.communicate()[0].strip()
+
+    # Process output to remove memory addresses and print warnings when heap is low
+    warnings_list = []
+    print('Memory usage for \'{0}\''.format(exec_filepath))
+    for line in stdout.split(os.linesep):
+        for index, pattern in enumerate(compiled_patterns):
+            match = re.match(pattern, line)
+            if match:
+                print(match.group('useful_info'))
+                if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
+                    warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
+                break
+        if len(compiled_patterns) == 0:
+            break
+    print('\n'.join(warnings_list))
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
@@ -48,12 +48,13 @@ set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPT
 set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
 set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb -T\"${NRF51822_LINKER_FLAGS_FILE_PATH}\"") 
+set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-m0 -mthumb -T\"${NRF51822_LINKER_FLAGS_FILE_PATH}\"")
 
 # used by the apply_target_rules function below:
-set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
-set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
-set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_SOFTDEVICE_HEX_FILE    "${NRF51822_SOFTDEVICE_FILE_PATH}")
+set(NRF51822_MERGE_HEX_SCRIPT       "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT     "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
+set(NRF51822_HEAP_WARNING_THRESHOLD 1024)
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -67,8 +68,12 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            VERBATIM
+        )
+        add_custom_command(TARGET ${target_name}
+            POST_BUILD
             # printing memory usage information
-            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name} ${NRF51822_HEAP_WARNING_THRESHOLD}
             COMMENT "printing memory usage information"
             VERBATIM
         )

--- a/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
+++ b/nordic-nrf51822-32k-gcc/CMake/toolchain.cmake
@@ -53,6 +53,7 @@ set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} -mcpu=cortex-
 # used by the apply_target_rules function below:
 set(NRF51822_SOFTDEVICE_HEX_FILE "${NRF51822_SOFTDEVICE_FILE_PATH}")
 set(NRF51822_MERGE_HEX_SCRIPT    "${CMAKE_CURRENT_LIST_DIR}/../scripts/merge_hex.py")
+set(NRF51822_MEMORY_INFO_SCRIPT  "${CMAKE_CURRENT_LIST_DIR}/../scripts/memory_info.py")
 
 # define a function for yotta to apply target-specific rules to build products,
 # in our case we need to convert the built elf file to .hex, and add the
@@ -66,6 +67,9 @@ function(yotta_apply_target_rules target_type target_name)
             # and append the softdevice hex file
             COMMAND python ${NRF51822_MERGE_HEX_SCRIPT} ${NRF51822_SOFTDEVICE_HEX_FILE} ${target_name}.hex ${target_name}-combined.hex
             COMMENT "hexifying and adding softdevice to ${target_name}"
+            # printing memory usage information
+            COMMAND python ${NRF51822_MEMORY_INFO_SCRIPT} ${target_name}
+            COMMENT "printing memory usage information"
             VERBATIM
         )
     endif()

--- a/nordic-nrf51822-32k-gcc/scripts/memory_info.py
+++ b/nordic-nrf51822-32k-gcc/scripts/memory_info.py
@@ -80,9 +80,7 @@ def main(arguments):
                 if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
                     warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
                 break
-        if len(compiled_patterns) == 0:
-            break
-    print('\n'.join(warnings_list))
+    print(os.linesep.join(warnings_list))
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv[1:]))

--- a/nordic-nrf51822-32k-gcc/scripts/memory_info.py
+++ b/nordic-nrf51822-32k-gcc/scripts/memory_info.py
@@ -1,0 +1,88 @@
+#! /usr/bin/env python
+
+"""This script reads the map file generated after the build process and prints
+   memory layout information of an nRF51 application.
+   USAGE: mem_report.py exec_filepath
+"""
+
+import sys
+import os.path
+import re
+import subprocess
+from distutils import spawn
+
+WARNING_THRESHOLD = 1024
+ARM_SIZE_UTILITY  = 'arm-none-eabi-size'
+
+fail_color    = ''
+warning_color = ''
+
+# If colorama is present, set the fail color to red
+try:
+    from colorama import init, deinit, Fore
+    fail_color    = Fore.RED
+    warning_color = Fore.BLUE
+except:
+    pass
+
+generic_pattern   = '^(?P<useful_info>\\.(?P<section>{0})\\s+(?P<size>\\d+))\\s+\\d+$'
+compiled_patterns = [re.compile('^(?P<useful_info>(?P<section>section)\\s+size)\\s+addr$'),
+                     re.compile(generic_pattern.format('data')), re.compile(generic_pattern.format('bss')),
+                     re.compile(generic_pattern.format('heap')), re.compile(generic_pattern.format('stack'))]
+
+def fail(message):
+    print(fail_color + 'ERROR: ' + message)
+
+    # If we've included ANSI color in output, reset the output style
+    if fail_color:
+        print(Fore.RESET)
+        deinit()
+
+    return 1
+
+def warning(message):
+    output = warning_color + 'WARNING: ' + message
+
+    # If we've included ANSI color in output, reset the output style
+    if warning_color:
+        output += Fore.RESET
+        deinit()
+
+    return output
+
+def main(arguments):
+    # If using ANSI coloring is available, initialize colorama
+    if fail_color and warning_color:
+        init()
+
+    # Ensure the right number of arguments are supplied
+    if len(arguments) != 1:
+        return fail('Improper use of mem_report.py.\nUSAGE: mem_report.py exec_filepath')
+    exec_filepath = arguments[0]
+
+    # Test if required utility exists
+    if not spawn.find_executable(ARM_SIZE_UTILITY):
+        print(warning('\'{0}\' could not be found. No memory usage information will be reported.'.format(ARM_SIZE_UTILITY)))
+        return 0
+
+    # Execute arm-none-eabi-size and get output
+    process = subprocess.Popen([ARM_SIZE_UTILITY, '-A', exec_filepath], stdout=subprocess.PIPE)
+    stdout  = process.communicate()[0].strip()
+
+    # Process output to remove memory addresses and print warnings when heap is low
+    warnings_list = []
+    print('Memory usage for \'{0}\''.format(exec_filepath))
+    for line in stdout.split(os.linesep):
+        for index, pattern in enumerate(compiled_patterns):
+            match = re.match(pattern, line)
+            if match:
+                print(match.group('useful_info'))
+                if match.group('section') == 'heap' and WARNING_THRESHOLD > int(match.group('size')):
+                    warnings_list.append(warning('Available heap < {0} bytes'.format(WARNING_THRESHOLD)))
+                break
+        if len(compiled_patterns) == 0:
+            break
+    print('\n'.join(warnings_list))
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Add python script to all targets that prints usage memory usage information and outputs warnings when there is little heap memory.

*NOTE:* The regular expressions in the scripts for ARMCC and GCC targets are different because the `arm-none-eabi-size` utility reports the sections with different names. Hence the regular expressions are different to match the string patterns.